### PR TITLE
Return the latest token instead of panicking, even if it's expired

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -22,7 +22,8 @@ impl AuthenticationManager {
     pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, GCPAuthError> {
         let mut sa = self.service_account.lock().await;
         let mut token = sa.get_token(scopes);
-        if token.is_none() {
+
+        if token.is_none() || token.clone().unwrap().has_expired() {
             sa.refresh_token(&self.client, scopes).await?;
             token = sa.get_token(scopes);
         }

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -24,15 +24,8 @@ impl CustomServiceAccount {
 #[async_trait]
 impl ServiceAccount for CustomServiceAccount {
     fn get_token(&self, scopes: &[&str]) -> Option<Token> {
-        let key: Vec<_> = scopes.iter().map(|x| (*x).to_string()).collect();
-        let token = self
-            .tokens
-            .get(&key);
-        
-        if token.is_none() || token.unwrap().has_expired() {
-            return None;
-        }
-        Some(token.unwrap().clone())
+        let key: Vec<_> = scopes.iter().map(|x| x.to_string()).collect();
+        self.tokens.get(&key).cloned()
     }
 
     async fn refresh_token(&mut self, client: &HyperClient, scopes: &[&str]) -> Result<(), GCPAuthError> {

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -44,9 +44,6 @@ impl DefaultAuthorizedUser {
 #[async_trait]
 impl ServiceAccount for DefaultAuthorizedUser {
     fn get_token(&self, _scopes: &[&str]) -> Option<Token> {
-        if self.token.has_expired() {
-            return None;
-        }
         Some(self.token.clone())
     }
 

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -35,9 +35,6 @@ impl DefaultServiceAccount {
 #[async_trait]
 impl ServiceAccount for DefaultServiceAccount {
     fn get_token(&self, _scopes: &[&str]) -> Option<Token> {
-        if self.token.has_expired() {
-            return None;
-        }
         Some(self.token.clone())
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserializer};
+use serde::Deserializer;
 use serde::{Deserialize, Serialize};
 
 /// Represents an access token. All access tokens are Bearer tokens.
@@ -17,7 +17,7 @@ pub struct Token {
 impl Token {
     pub(crate) fn has_expired(&self) -> bool {
         self.expires_at
-            .map(|expiration_time| expiration_time - chrono::Duration::minutes(1) <= Utc::now())
+            .map(|expiration_time| expiration_time - chrono::Duration::seconds(30) <= Utc::now())
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
When running in cloudrun, the `metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token` endpoint will cache an access token until it's 60s from expiry. This project also considers a token to be expired 60 seconds before the real expiry.

This causes an issue in that there is a short period of time between the lib considering the token to be expired and the cloud run endpoint returning a new one. During this time the library panics with `Token obtained with refresh or failed before`. This happens consistently every 30 minutes in my project.

This pull request changes two things:
1. Don't consider the token to be expired until 30 seconds before true expiry - This allows ample time for the cloudrun endpoint to generate a new token.
2. Return the token even if it's considered expired instead of panicking - On top of preventing a panic, this also allows library users to handle an expired (or close to expired) token however they wish.

PS: Thanks for the super handy lib :+1: 