### PR TITLE
Use hyper-rustls instead of hyper-tls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,15 @@ readme = "README.md"
 license = "MIT"
 edition = "2018"
 
+[features]
+default = ["hyper-rustls/native-tokio"]
+webpki-roots = ["hyper-rustls/webpki-tokio"]
+
 [dependencies]
 base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "0.13.5"
-hyper-rustls = "0.21"
+hyper-rustls = { version = "0.21", default-features = false }
 log = "0.4"
 rustls = "0.18.1"
 serde = {version = "1.0", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-base64 = "0.12"
+base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "0.13.5"
 hyper-rustls = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "0.13.5"
-hyper-tls = "0.4"
+hyper-rustls = "0.20"
 log = "0.4"
 rustls = "0.17"
 serde = {version = "1.0", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 hyper = "0.13.5"
-hyper-rustls = "0.20"
+hyper-rustls = "0.21"
 log = "0.4"
-rustls = "0.17"
+rustls = "0.18.1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 tokio = { version = "0.2", features = ["fs"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub use error::GCPAuthError;
 pub use types::Token;
 
 use hyper::Client;
-use hyper_tls::HttpsConnector;
+use hyper_rustls::HttpsConnector;
 use tokio::sync::Mutex;
 
 /// Initialize GCP authentication

--- a/src/types.rs
+++ b/src/types.rs
@@ -41,4 +41,4 @@ where
     Ok(s)
 }
 
-pub type HyperClient = hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>;
+pub type HyperClient = hyper::Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>;


### PR DESCRIPTION
Since this project already depends on rustls for other things, I think it
makes sense to use it for the actual TLS connections, too. This also helps
when building containers, since you don't have to deal with the openssl build.