### PR TITLE
Rename GCPAuthError to just Error

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -4,11 +4,7 @@ use tokio::sync::Mutex;
 #[async_trait]
 pub trait ServiceAccount: Send {
     fn get_token(&self, scopes: &[&str]) -> Option<Token>;
-    async fn refresh_token(
-        &mut self,
-        client: &HyperClient,
-        scopes: &[&str],
-    ) -> Result<(), GCPAuthError>;
+    async fn refresh_token(&mut self, client: &HyperClient, scopes: &[&str]) -> Result<(), Error>;
 }
 
 /// Authentication manager is responsible for caching and obtaing credentials for the required scope
@@ -23,7 +19,7 @@ impl AuthenticationManager {
     /// Requests Bearer token for the provided scope
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}"
-    pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, GCPAuthError> {
+    pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, Error> {
         let mut sa = self.service_account.lock().await;
         let mut token = sa.get_token(scopes);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 /// Enumerates all possible errors returned by this library.
 #[derive(Error, Debug)]
-pub enum GCPAuthError {
+pub enum Error {
     /// No available authentication method was discovered
     ///
     /// Application can authenticate against GCP using:
@@ -12,7 +12,7 @@ pub enum GCPAuthError {
     /// All authentication methods have been tested and none succeeded.
     /// Service account file can be donwloaded from GCP in json format.
     #[error("No available authentication method was discovered")]
-    NoAuthMethod(Box<GCPAuthError>, Box<GCPAuthError>, Box<GCPAuthError>),
+    NoAuthMethod(Box<Error>, Box<Error>, Box<Error>),
 
     /// Error in underlaying RustTLS library.
     /// Might signal problem with establishin secure connection using trusted certificates

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -82,12 +82,12 @@ pub(crate) struct JWTSigner {
 }
 
 impl JWTSigner {
-    pub fn new(private_key: &str) -> Result<Self, GCPAuthError> {
+    pub fn new(private_key: &str) -> Result<Self, Error> {
         let key = decode_rsa_key(private_key)?;
-        let signing_key = sign::RSASigningKey::new(&key).map_err(|_| GCPAuthError::SignerInit)?;
+        let signing_key = sign::RSASigningKey::new(&key).map_err(|_| Error::SignerInit)?;
         let signer = signing_key
             .choose_scheme(&[rustls::SignatureScheme::RSA_PKCS1_SHA256])
-            .ok_or_else(|| GCPAuthError::SignerSchemeError)?;
+            .ok_or_else(|| Error::SignerSchemeError)?;
         Ok(JWTSigner { signer })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,13 @@ mod types;
 mod util;
 mod prelude {
     pub(crate) use {
-        crate::error::GCPAuthError, crate::types::HyperClient, crate::types::Token,
-        crate::util::HyperExt, async_trait::async_trait, hyper::Request, serde::Deserialize,
-        serde::Serialize, std::collections::HashMap, std::path::Path,
+        crate::error::Error, crate::types::HyperClient, crate::types::Token, crate::util::HyperExt,
+        async_trait::async_trait, hyper::Request, serde::Deserialize, serde::Serialize,
+        std::collections::HashMap, std::path::Path,
     };
 }
 pub use authentication_manager::AuthenticationManager;
-pub use error::GCPAuthError;
+pub use error::Error;
 pub use types::Token;
 
 use hyper::Client;
@@ -77,7 +77,7 @@ use tokio::sync::Mutex;
 /// Initialize GCP authentication
 ///
 /// Returns `AuthenticationManager` which can be used to obtain tokens
-pub async fn init() -> Result<AuthenticationManager, GCPAuthError> {
+pub async fn init() -> Result<AuthenticationManager, Error> {
     let https = HttpsConnector::new();
     let client = Client::builder().build::<_, hyper::Body>(https);
 
@@ -102,7 +102,7 @@ pub async fn init() -> Result<AuthenticationManager, GCPAuthError> {
             service_account: Mutex::new(Box::new(user_account)),
         });
     }
-    Err(GCPAuthError::NoAuthMethod(
+    Err(Error::NoAuthMethod(
         Box::new(custom.unwrap_err()),
         Box::new(default.unwrap_err()),
         Box::new(user.unwrap_err()),

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,26 +3,26 @@ use serde::de;
 
 #[async_trait]
 pub trait HyperExt {
-    async fn deserialize<T>(self) -> Result<T, GCPAuthError>
+    async fn deserialize<T>(self) -> Result<T, Error>
     where
         T: de::DeserializeOwned;
 }
 
 #[async_trait]
 impl HyperExt for hyper::Response<hyper::body::Body> {
-    async fn deserialize<T>(self) -> Result<T, GCPAuthError>
+    async fn deserialize<T>(self) -> Result<T, Error>
     where
         T: de::DeserializeOwned,
     {
         if !self.status().is_success() {
             log::error!("Server responded with error");
-            return Err(GCPAuthError::ServerUnavailable);
+            return Err(Error::ServerUnavailable);
         }
         let (_, body) = self.into_parts();
         let body = hyper::body::to_bytes(body)
             .await
-            .map_err(GCPAuthError::ConnectionError)?;
-        let token = serde_json::from_slice(&body).map_err(GCPAuthError::ParsingError)?;
+            .map_err(Error::ConnectionError)?;
+        let token = serde_json::from_slice(&body).map_err(Error::ParsingError)?;
 
         Ok(token)
     }


### PR DESCRIPTION
Naming the error type Error seems idiomatic. Additionally, the GCPAuthError
name does not comply with the API guidelines for acronyms.