### PR TITLE
Revert "Use std::sync::Mutex instead of an async variant"

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use std::sync::Mutex;
+use tokio::sync::Mutex;
 
 #[async_trait]
 pub trait ServiceAccount: Send {
@@ -20,7 +20,7 @@ impl AuthenticationManager {
     ///
     /// Token can be used in the request authorization header in format "Bearer {token}"
     pub async fn get_token(&self, scopes: &[&str]) -> Result<Token, Error> {
-        let mut sa = self.service_account.lock().unwrap();
+        let mut sa = self.service_account.lock().await;
         let mut token = sa.get_token(scopes);
 
         if token.is_none() || token.clone().unwrap().has_expired() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub use types::Token;
 
 use hyper::Client;
 use hyper_rustls::HttpsConnector;
-use std::sync::Mutex;
+use tokio::sync::Mutex;
 
 /// Initialize GCP authentication
 ///


### PR DESCRIPTION
This reverts commit a4e02744232bb75bfdf761a6038da8aad1d0ce69.

While the compiler didn't point this out while testing the crate itself, it immediately complained when I tried to use 0.2 in my application: the futures generated by `AuthenticationManager::get_tokens()` do currently hold a lock across await points. I think there are some further opportunities to improve this, but let's start by fixing this.