### PR TITLE
Improve locking for real this time

### DIFF
--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -1,11 +1,11 @@
 use crate::authentication_manager::ServiceAccount;
 use crate::prelude::*;
-use std::sync::Mutex;
+use std::sync::RwLock;
 use tokio::fs;
 
 #[derive(Debug)]
 pub struct CustomServiceAccount {
-    tokens: Mutex<HashMap<Vec<String>, Token>>,
+    tokens: RwLock<HashMap<Vec<String>, Token>>,
     credentials: ApplicationCredentials,
 }
 
@@ -18,7 +18,7 @@ impl CustomServiceAccount {
         let credentials = ApplicationCredentials::from_file(path).await?;
         Ok(Self {
             credentials,
-            tokens: Mutex::new(HashMap::new()),
+            tokens: RwLock::new(HashMap::new()),
         })
     }
 }
@@ -27,7 +27,7 @@ impl CustomServiceAccount {
 impl ServiceAccount for CustomServiceAccount {
     fn get_token(&self, scopes: &[&str]) -> Option<Token> {
         let key: Vec<_> = scopes.iter().map(|x| x.to_string()).collect();
-        self.tokens.lock().unwrap().get(&key).cloned()
+        self.tokens.read().unwrap().get(&key).cloned()
     }
 
     async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error> {
@@ -56,7 +56,7 @@ impl ServiceAccount for CustomServiceAccount {
             .deserialize::<Token>()
             .await?;
         let key = scopes.iter().map(|x| (*x).to_string()).collect();
-        self.tokens.lock().unwrap().insert(key, token.clone());
+        self.tokens.write().unwrap().insert(key, token.clone());
         Ok(token)
     }
 }

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -1,10 +1,11 @@
 use crate::authentication_manager::ServiceAccount;
 use crate::prelude::*;
+use std::sync::Mutex;
 use tokio::fs;
 
 #[derive(Debug)]
 pub struct CustomServiceAccount {
-    tokens: HashMap<Vec<String>, Token>,
+    tokens: Mutex<HashMap<Vec<String>, Token>>,
     credentials: ApplicationCredentials,
 }
 
@@ -17,7 +18,7 @@ impl CustomServiceAccount {
         let credentials = ApplicationCredentials::from_file(path).await?;
         Ok(Self {
             credentials,
-            tokens: HashMap::new(),
+            tokens: Mutex::new(HashMap::new()),
         })
     }
 }
@@ -26,10 +27,10 @@ impl CustomServiceAccount {
 impl ServiceAccount for CustomServiceAccount {
     fn get_token(&self, scopes: &[&str]) -> Option<Token> {
         let key: Vec<_> = scopes.iter().map(|x| x.to_string()).collect();
-        self.tokens.get(&key).cloned()
+        self.tokens.lock().unwrap().get(&key).cloned()
     }
 
-    async fn refresh_token(&mut self, client: &HyperClient, scopes: &[&str]) -> Result<(), Error> {
+    async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error> {
         use crate::jwt::Claims;
         use crate::jwt::JWTSigner;
         use crate::jwt::GRANT_TYPE;
@@ -52,11 +53,11 @@ impl ServiceAccount for CustomServiceAccount {
             .request(request)
             .await
             .map_err(Error::OAuthConnectionError)?
-            .deserialize()
+            .deserialize::<Token>()
             .await?;
         let key = scopes.iter().map(|x| (*x).to_string()).collect();
-        self.tokens.insert(key, token);
-        Ok(())
+        self.tokens.lock().unwrap().insert(key, token.clone());
+        Ok(token)
     }
 }
 

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -2,17 +2,18 @@ use crate::authentication_manager::ServiceAccount;
 use crate::prelude::*;
 use hyper::body::Body;
 use hyper::Method;
+use std::sync::Mutex;
 
 #[derive(Debug)]
 pub struct DefaultServiceAccount {
-    token: Token,
+    token: Mutex<Token>,
 }
 
 impl DefaultServiceAccount {
     const DEFAULT_TOKEN_GCP_URI: &'static str = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
 
     pub async fn new(client: &HyperClient) -> Result<Self, Error> {
-        let token = Self::get_token(client).await?;
+        let token = Mutex::new(Self::get_token(client).await?);
         Ok(Self { token })
     }
 
@@ -41,12 +42,12 @@ impl DefaultServiceAccount {
 #[async_trait]
 impl ServiceAccount for DefaultServiceAccount {
     fn get_token(&self, _scopes: &[&str]) -> Option<Token> {
-        Some(self.token.clone())
+        Some(self.token.lock().unwrap().clone())
     }
 
-    async fn refresh_token(&mut self, client: &HyperClient, _scopes: &[&str]) -> Result<(), Error> {
+    async fn refresh_token(&self, client: &HyperClient, _scopes: &[&str]) -> Result<Token, Error> {
         let token = Self::get_token(client).await?;
-        self.token = token;
-        Ok(())
+        *self.token.lock().unwrap() = token.clone();
+        Ok(token)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ pub use types::Token;
 
 use hyper::Client;
 use hyper_rustls::HttpsConnector;
-use tokio::sync::Mutex;
 
 /// Initialize GCP authentication
 ///
@@ -85,21 +84,21 @@ pub async fn init() -> Result<AuthenticationManager, Error> {
     if let Ok(service_account) = default {
         return Ok(AuthenticationManager {
             client: client.clone(),
-            service_account: Mutex::new(Box::new(service_account)),
+            service_account: Box::new(service_account),
         });
     }
     let custom = custom_service_account::CustomServiceAccount::new().await;
     if let Ok(service_account) = custom {
         return Ok(AuthenticationManager {
             client,
-            service_account: Mutex::new(Box::new(service_account)),
+            service_account: Box::new(service_account),
         });
     }
     let user = default_authorized_user::DefaultAuthorizedUser::new(&client).await;
     if let Ok(user_account) = user {
         return Ok(AuthenticationManager {
             client,
-            service_account: Mutex::new(Box::new(user_account)),
+            service_account: Box::new(user_account),
         });
     }
     Err(Error::NoAuthMethod(


### PR DESCRIPTION
* Push the lock into the `ServiceAccount` impls, which means the static data required to get a new token isn't locked
* Let `ServiceAccount::refresh_token()` return a clone of the new token so no extra locking is required
* Now no locks need to be held across await points!
* Since the locking should be read-heavy, change from a `Mutex` to an `RwLock`