### PR TITLE
Add API to access the project ID

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 
 #[async_trait]
 pub trait ServiceAccount: Send + Sync {
+    async fn project_id(&self, client: &HyperClient) -> Result<String, Error>;
     fn get_token(&self, scopes: &[&str]) -> Option<Token>;
     async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error>;
 }
@@ -26,5 +27,12 @@ impl AuthenticationManager {
         self.service_account
             .refresh_token(&self.client, scopes)
             .await
+    }
+
+    /// Request the project ID for the authenticating account
+    ///
+    /// This is only available for service account-based authentication methods.
+    pub async fn project_id(&self) -> Result<String, Error> {
+        self.service_account.project_id(&self.client).await
     }
 }

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -25,6 +25,13 @@ impl CustomServiceAccount {
 
 #[async_trait]
 impl ServiceAccount for CustomServiceAccount {
+    async fn project_id(&self, _: &HyperClient) -> Result<String, Error> {
+        match &self.credentials.project_id {
+            Some(pid) => Ok(pid.clone()),
+            None => Err(Error::ProjectIdNotFound),
+        }
+    }
+
     fn get_token(&self, scopes: &[&str]) -> Option<Token> {
         let key: Vec<_> = scopes.iter().map(|x| x.to_string()).collect();
         self.tokens.read().unwrap().get(&key).cloned()

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -53,6 +53,10 @@ impl DefaultAuthorizedUser {
 
 #[async_trait]
 impl ServiceAccount for DefaultAuthorizedUser {
+    async fn project_id(&self, _: &HyperClient) -> Result<String, Error> {
+        Err(Error::NoProjectId)
+    }
+
     fn get_token(&self, _scopes: &[&str]) -> Option<Token> {
         Some(self.token.read().unwrap().clone())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,6 +82,18 @@ pub enum Error {
     #[error("Home directory not found")]
     NoHomeDir,
 
+    /// Project ID not supported for current authentication method
+    #[error("Project ID not supported for current authentication method")]
+    NoProjectId,
+
+    /// Project ID not found through current authentication method
+    #[error("Project ID not found through current authentication method")]
+    ProjectIdNotFound,
+
+    /// Project ID is invalid UTF-8
+    #[error("Project ID is invalid UTF-8")]
+    ProjectIdNonUtf8,
+
     /// Represents all other cases of `std::io::Error`.
     #[error(transparent)]
     IOError(#[from] std::io::Error),


### PR DESCRIPTION
I wrote this up to see how it feels, but I'm not completely sure it fits with the scope of your project.

For my application, I need to write trace spans to Google's Cloud Trace. Traces require a project field at the top level that matches the IAM project, so I need a way to access the project ID. Currently, I have some code like this that fetches this data:

```rust
    async fn project_id() -> String {
        if let Ok(path) = env::var("GOOGLE_APPLICATION_CREDENTIALS") {
            let mut f = File::open(path).unwrap();
            let data = serde_json::from_reader::<_, ServiceAccount>(&mut f).unwrap();
            data.project_id
        } else {
            let req = reqwest::Client::new()
                .get("http://metadata.google.internal/computeMetadata/v1/project/project-id")
                .header("Metadata-Flavor", "Google");
            req.send().await.unwrap().text().await.unwrap()
        }
    }
```

However, this duplicates quite a bit of the logic that you already have in gcp_auth. So this PR adds a way to access that information from the `AuthenticationManager`, but it feels a little unnatural, especially because it doesn't fit with the default user account method. (BTW, I couldn't find a file matching the `/.config/gcloud/application_default_credentials.json`; however, I did find one matching the `UserCredentials` structure in `~/.config/gcloud/legacy_credentials/<email>/adc.json`.)

So this is just an exploration of what it could look like, feel free to close it if this isn't something that fits within the desired scope.

An alternative solution could be to break down the `AuthenticationManager` abstraction a bit, giving the user access to an enum with variants for each of the methods (instead of a trait object), with public API methods on the contained types to give users fine-grained access to what's available for that particular method.