### PR TITLE
Revert dependency changes from e2288cbbfc9eb821679bc3ae836d3912de8aef0f

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ log = "0.4"
 rustls = "0.18.1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tokio = { version = "0.3", features = ["fs"] }
-url = "2.2"
+tokio = { version = "0.2", features = ["fs"] }
+url = "2"
 async-trait = "0.1"
 thiserror = "1.0"
 dirs-next = "2.0"


### PR DESCRIPTION
Hey, thanks for merging #14! I noticed that, as part of #16 you introduced a number of changes to the dependencies, some of which make it harder for me to use your project. I was also a little surprised that some of your changes seem to have widened the version ranges allowed (hyper "0.13.5" -> "0.13", async-trait "0.1.31" -> "0.1") whereas others narrowed it (url "2" -> "2.2"). In particular, these changes make life harder for my project:

- tokio 0.2 -> 0.3: this is a legitimate upgrade, but unfortunately the ecosystem has not moved along yet. In particular, hyper 0.13 actually relies on 0.2, so as written this change probably won't work exactly as you expect (maybe spawn two runtimes). My application is still relying on tokio 0.2 since it also uses hyper (and reqwest, which will update after hyper).
- url 2 -> 2.2: this change doesn't make much sense to me since 2.2 is semver-compatible with 2, and gcp_auth doesn't (as far as I can tell) actually rely on any of the changes in version 2.2. Additionally, for various reasons my project currently relies on a fork of url 2.1.1, so life would be a little easier to just keep this at 2 (but would still allow other downstream crates to use 2.2 with gcp_auth).