### PR TITLE
Expose function `has_expired` from Token

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -15,7 +15,8 @@ pub struct Token {
 }
 
 impl Token {
-    pub(crate) fn has_expired(&self) -> bool {
+    /// Define if the token has has_expired
+    pub fn has_expired(&self) -> bool {
         self.expires_at
             .map(|expiration_time| expiration_time - chrono::Duration::seconds(30) <= Utc::now())
             .unwrap_or(false)


### PR DESCRIPTION
In many problems there is a need to verify if token has expired, for example, implementing a client for another service (for me, it is bigquery) and deciding when there is a need to refresh the token.