### PR TITLE
 Add new_from_file_path to CustomServiceAccount

### DIFF
--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -10,15 +10,7 @@ pub struct CustomServiceAccount {
 }
 
 impl CustomServiceAccount {
-    const GOOGLE_APPLICATION_CREDENTIALS: &'static str = "GOOGLE_APPLICATION_CREDENTIALS";
-
-    pub async fn new() -> Result<Self, Error> {
-        let path = std::env::var(Self::GOOGLE_APPLICATION_CREDENTIALS)
-            .map_err(|_| Error::AplicationProfileMissing)?;
-        Self::new_from_file_path(path.as_str()).await      
-    }
-
-    pub async fn new_from_file_path(path: &str) -> Result<Self, Error> {
+    pub async fn from_file(path: &str) -> Result<Self, Error> {
         let credentials = ApplicationCredentials::from_file(path).await?;
         Ok(Self {
             credentials,

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -15,6 +15,10 @@ impl CustomServiceAccount {
     pub async fn new() -> Result<Self, Error> {
         let path = std::env::var(Self::GOOGLE_APPLICATION_CREDENTIALS)
             .map_err(|_| Error::AplicationProfileMissing)?;
+        Self::new_from_file_path(path.as_str()).await      
+    }
+
+    pub async fn new_from_file_path(path: &str) -> Result<Self, Error> {
         let credentials = ApplicationCredentials::from_file(path).await?;
         Ok(Self {
             credentials,


### PR DESCRIPTION
Allow to create a CustomServiceAccount from custom file path instead of default variable path.