### PR TITLE
Don't require env GOOGLE_APPLICATION_CREDENTIALS to be defined.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 Cargo.lock
+
+# Intellij project files
+*.iml
+.idea

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -1,4 +1,5 @@
 use crate::authentication_manager::ServiceAccount;
+use crate::error::Error::AplicationProfileMissing;
 use crate::prelude::*;
 use std::sync::RwLock;
 use tokio::fs;
@@ -16,6 +17,13 @@ impl CustomServiceAccount {
             credentials,
             tokens: RwLock::new(HashMap::new()),
         })
+    }
+
+    pub async fn from_env() -> Result<Self, Error> {
+        const GOOGLE_APPLICATION_CREDENTIALS: &str = "GOOGLE_APPLICATION_CREDENTIALS";
+        let path =
+            std::env::var(GOOGLE_APPLICATION_CREDENTIALS).map_err(|_| AplicationProfileMissing)?;
+        CustomServiceAccount::from_file(&path).await
     }
 }
 

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -87,14 +87,14 @@ impl JWTSigner {
         let signing_key = sign::RSASigningKey::new(&key).map_err(|_| Error::SignerInit)?;
         let signer = signing_key
             .choose_scheme(&[rustls::SignatureScheme::RSA_PKCS1_SHA256])
-            .ok_or_else(|| Error::SignerSchemeError)?;
+            .ok_or(Error::SignerSchemeError)?;
         Ok(JWTSigner { signer })
     }
 
     pub fn sign_claims(&self, claims: &Claims) -> Result<String, rustls::TLSError> {
         let mut jwt_head = Self::encode_claims(claims);
         let signature = self.signer.sign(jwt_head.as_bytes())?;
-        jwt_head.push_str(".");
+        jwt_head.push('.');
         append_base64(&signature, &mut jwt_head);
         Ok(jwt_head)
     }
@@ -104,7 +104,7 @@ impl JWTSigner {
     fn encode_claims(claims: &Claims) -> String {
         let mut head = String::new();
         append_base64(GOOGLE_RS256_HEAD, &mut head);
-        head.push_str(".");
+        head.push('.');
         append_base64(&serde_json::to_string(&claims).unwrap(), &mut head);
         head
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,10 @@ use hyper_rustls::HttpsConnector;
 ///
 /// Returns `AuthenticationManager` which can be used to obtain tokens
 pub async fn from_credentials_file(path: &str) -> Result<AuthenticationManager, Error> {
-    get_service_account(Some(path.to_owned())).await
+    get_authentication_manager(Some(path.to_owned())).await
 }
 
-async fn get_service_account(
+async fn get_authentication_manager(
     credential_path: Option<String>,
 ) -> Result<AuthenticationManager, Error> {
     #[cfg(feature = "webpki-roots")]
@@ -134,5 +134,5 @@ async fn get_service_account(
 ///
 /// Returns `AuthenticationManager` which can be used to obtain tokens
 pub async fn init() -> Result<AuthenticationManager, Error> {
-    get_service_account(None).await
+    get_authentication_manager(None).await
 }


### PR DESCRIPTION
I opted to keep the APIs consistent so there's a little more indirection as a result.