### PR TITLE
Replace chrono with time 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ webpki-roots = ["hyper-rustls/webpki-roots"]
 
 [dependencies]
 base64 = "0.13"
-chrono = { version = "0.4", features = ["serde"] }
+time = { version = "0.3.5", features = ["serde"] }
 hyper = { version = "0.14.2", features = ["client", "runtime", "http2"] }
 hyper-rustls = { version = "0.22.1", default-features = false, features = ["tokio-runtime"] }
 log = "0.4"

--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -62,7 +62,7 @@ impl<'a> Claims<'a> {
     where
         T: std::string::ToString,
     {
-        let iat = chrono::Utc::now().timestamp();
+        let iat = time::OffsetDateTime::now_utc().unix_timestamp();
         let expiry = iat + 3600 - 5; // Max validity is 1h.
 
         let scope: String = scopes


### PR DESCRIPTION
Since chrono has security advisories, use time 0.3.