### PR TITLE
Add from_credentials_json function.

### DIFF
--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -24,6 +24,13 @@ impl CustomServiceAccount {
             tokens: RwLock::new(HashMap::new()),
         })
     }
+
+    pub(crate) fn from_json(s: &str) -> Result<Self, Error> {
+        Ok(Self {
+            credentials: ApplicationCredentials::from_json(s)?,
+            tokens: RwLock::new(HashMap::new()),
+        })
+    }
 }
 
 #[async_trait]
@@ -100,5 +107,9 @@ impl ApplicationCredentials {
             .await
             .map_err(Error::ApplicationProfilePath)?;
         Ok(serde_json::from_str(&content).map_err(Error::ApplicationProfileFormat)?)
+    }
+
+    fn from_json(s: &str) -> Result<ApplicationCredentials, Error> {
+        Ok(serde_json::from_str(s).map_err(Error::ApplicationProfileFormat)?)
     }
 }

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -110,6 +110,6 @@ impl ApplicationCredentials {
     }
 
     fn from_json(s: &str) -> Result<ApplicationCredentials, Error> {
-        Ok(serde_json::from_str(s).map_err(Error::ApplicationProfileFormat)?)
+        serde_json::from_str(s).map_err(Error::ApplicationProfileFormat)
     }
 }

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -106,7 +106,7 @@ impl ApplicationCredentials {
         let content = fs::read_to_string(path)
             .await
             .map_err(Error::ApplicationProfilePath)?;
-        Ok(serde_json::from_str(&content).map_err(Error::ApplicationProfileFormat)?)
+        ApplicationCredentials::from_json(&content)
     }
 
     fn from_json(s: &str) -> Result<ApplicationCredentials, Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,13 +7,12 @@ pub enum Error {
     /// Application can authenticate against GCP using:
     ///
     /// - Default service account - available inside GCP platform using GCP Instance Metadata server
-    /// - Service account file - provided using `GOOGLE_APPLICATION_CREDENTIALS` with path
     /// - GCloud authorized user - retrieved using `gcloud auth` command
     ///
     /// All authentication methods have been tested and none succeeded.
     /// Service account file can be downloaded from GCP in json format.
     #[error("No available authentication method was discovered")]
-    NoAuthMethod(Box<Error>, Box<Error>, Box<Error>, Box<Error>),
+    NoAuthMethod(Box<Error>, Box<Error>, Box<Error>),
 
     /// Error in underlying RustTLS library.
     /// Might signal problem with establishing secure connection using trusted certificates


### PR DESCRIPTION
See #45.

This adds a `from_credentials_json` function so that the credentials can be parsed from a JSON string.

I changed `get_authentication_manager` such that instead of an optional path, one can pass an `Option<CustomServiceAccount>`. The `from_credentials_file` function now handles the reading of the given path and the `from_credentials_json` handles the reading of the given JSON.

I updated the `init()` function such that it first checks `GOOGLE_APPLICATION_CREDENTIALS` and if it exists, it will try to read from that path (if not it errors). If no such env variable exists, it calls `get_authentication_manager` with `None`.