### PR TITLE
Update documentation, introduce doctests and restructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ which = "4.2"
 
 [dev-dependencies]
 env_logger = "0.9"
-tokio = { version = "1.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.1", features = ["macros", "parking_lot", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.7.0"
+version = "0.7.1"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GCP Auth
+
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -10,90 +11,42 @@
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
 
-GCP Auth is a simple, minimal authentication library for Google Cloud Platform (GCP)
-providing authentication using services accounts. Once authenticated, the service
+GCP auth provides authentication using service accounts Google Cloud Platform (GCP)
+
+GCP auth is a simple, minimal authentication library for Google Cloud Platform (GCP)
+providing authentication using service accounts. Once authenticated, the service
 account can be used to acquire bearer tokens for use in authenticating against GCP
 services.
 
-The library looks for authentication methods in the following order:
+The library supports the following methods of retrieving tokens:
 
-1. Path to service account JSON configuration file using GOOGLE_APPLICATION_CREDENTIALS
-environment variable. The service account configuration file can be downloaded in the
-IAM service when displaying service account detail. The downloaded JSON file should 
-be provided without any further modification.
-2. Invoking the library inside GCP environment fetches the default service account
-for the service and he application is authenticated using that particular account
-3. Application default credentials. Local user authetincation for development purposes
-created using `gcloud auth` application.
-4. If none of the above can be used an error occurs
+1. Reading custom service account credentials from the path pointed to by the
+   `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Alternatively, custom service
+   account credentials can be read from a JSON file or string.
+2. Retrieving a token from the `gcloud` CLI tool, if it is available on the `PATH`.
+3. Use the default service account by retrieving a token from the metadata server.
+4. Look for credentials in `.config/gcloud/application_default_credentials.json`;
+   if found, use these credentials to request refresh tokens.
 
-Tokens should not be cached in the application; before every use a new token should
-be requested. The GCP auth library contains logic to determine if an already
-available token can be used, or if a new token should be requested.
+For more detailed information and examples, see the [docs][docs-url].
 
-## Default service account
+This crate does not currently support Windows.
 
-When running inside GCP the library can be asked without any further configuration to
-provide a bearer token for the current service account of the service.
+## Simple usage
 
-```rust
-let scopes = &["https://www.googleapis.com/auth/bigquery/"];
-let authentication_manager = gcp_auth::init().await?;
+The default way to use this library is to get instantiate an `AuthenticationManager`. It will
+find the appropriate authentication method and use it to retrieve tokens.
+
+```rust,no_run
+use gcp_auth::AuthenticationManager;
+
+let authentication_manager = AuthenticationManager::new().await?;
+let scopes = &["https://www.googleapis.com/auth/cloud-platform"];
 let token = authentication_manager.get_token(scopes).await?;
-```
-
-## Custom service account
-
-When running outside of GCP (for example, on a developer's laptop), a custom service
-account may be used to grant some permissions. To use a custom service account a
-configuration file containing a private key can be downloaded in IAM service for the
-service account you intend to use. The configuration file has to be available to the
-application at run time. The path to the configuration file is specified by the
-`GOOGLE_APPLICATION_CREDENTIALS` environment variable.
-
-```rust
-// With the GOOGLE_APPLICATION_CREDENTIALS environment variable set
-let scopes = &["https://www.googleapis.com/auth/bigquery/"];
-let authentication_manager = gcp_auth::init().await?;
-let token = authentication_manager.get_token(&scopes).await?;
-```
-
-You may instantiate `authentication_manager` from a credentials file path using the method `from_credentials_file`:
-
-```async
- // `credentials_path` variable is the path for the credentials `.json` file.
- let authentication_manager = gcp_auth::from_credentials_file(credentials_path).await?;
- let token = authentication_manager.get_token().await?;
-```
-
-## Local user authentication
-
-This authentication method allows developers to authenticate again GCP when
-developing locally. Its use should be limited to development. Credentials can be
-set up using the `gcloud auth` utility. Credentials are read from file `~/.config/gcloud/application_default_credentials.json`.
-
-## FAQ
-
-### Does the library support windows?
-
-No.
-
-## Getting tokens in multithreaded async programs
-
-There is a simple pattern that can be used in async/await programs,
-to avoid creating multiple instances of `AuthenticationManager`:
-
-```rust
-use once_cell::sync::Lazy;
-
-static AUTHENTICATOR: Lazy<gcp_auth::AuthenticationManager> =
-    Lazy::new(|| {
-        futures::executor::block_on(gcp_auth::init()).expect("Should set-up auth")
-    });
 ```
 
 # License
 
-Parts of the implementatino have been sourced from [yup-oauth2](https://github.com/dermesser/yup-oauth2).
+Parts of the implementation have been sourced from [yup-oauth2](https://github.com/dermesser/yup-oauth2).
 
 Licensed under [MIT license](http://opensource.org/licenses/MIT).

--- a/src/custom_service_account.rs
+++ b/src/custom_service_account.rs
@@ -14,6 +14,8 @@ use crate::util::HyperExt;
 ///
 /// Once initialized, a [`CustomServiceAccount`] can be converted into an [`AuthenticationManager`]
 /// using the applicable `From` implementation.
+///
+/// [`AuthenticationManager`]: crate::AuthenticationManager
 #[derive(Debug)]
 pub struct CustomServiceAccount {
     credentials: ApplicationCredentials,


### PR DESCRIPTION
I forgot to update the documentation for the API changes introduced in #50. This focuses the documentation more in the crate root, with some content copied into the README. The doctests should help check that the examples are up to date. Bumps the version so we can publish this in order to get the updated README out to crates.io.