### PR TITLE
feat: cache token for GCloudAuthorizedUser

### DIFF
--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -47,7 +47,7 @@ impl AuthenticationManager {
         }
 
         let client = types::client();
-        let gcloud_error = match GCloudAuthorizedUser::new() {
+        let gcloud_error = match GCloudAuthorizedUser::new().await {
             Ok(service_account) => {
                 tracing::debug!("Using GCloudAuthorizedUser");
                 return Ok(Self::build(client, service_account));

--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::RwLock;
 
 use async_trait::async_trait;
 use which::which;
@@ -14,18 +15,24 @@ use crate::Token;
 pub(crate) struct GCloudAuthorizedUser {
     gcloud: PathBuf,
     project_id: Option<String>,
+    token: RwLock<Token>,
 }
 
 impl GCloudAuthorizedUser {
-    pub(crate) fn new() -> Result<Self, Error> {
+    pub(crate) async fn new() -> Result<Self, Error> {
         let gcloud = which("gcloud").map_err(|_| GCloudNotFound)?;
         let project_id = run(&gcloud, &["config", "get-value", "project"]).ok();
-        Ok(Self { gcloud, project_id })
+        let token = RwLock::new(Self::get_token_via_gcloud_cmd(&gcloud)?);
+        Ok(Self {
+            gcloud,
+            project_id,
+            token,
+        })
     }
 
-    fn token(&self) -> Result<Token, Error> {
+    fn get_token_via_gcloud_cmd(gcloud: &Path) -> Result<Token, Error> {
         Ok(Token::from_string(run(
-            &self.gcloud,
+            gcloud,
             &["auth", "print-access-token", "--quiet"],
         )?))
     }
@@ -38,11 +45,13 @@ impl ServiceAccount for GCloudAuthorizedUser {
     }
 
     fn get_token(&self, _scopes: &[&str]) -> Option<Token> {
-        None
+        Some(self.token.read().unwrap().clone())
     }
 
     async fn refresh_token(&self, _client: &HyperClient, _scopes: &[&str]) -> Result<Token, Error> {
-        self.token()
+        let token = Self::get_token_via_gcloud_cmd(&self.gcloud)?;
+        *self.token.write().unwrap() = token.clone();
+        Ok(token)
     }
 }
 
@@ -66,11 +75,11 @@ fn run(gcloud: &Path, cmd: &[&str]) -> Result<String, Error> {
 mod tests {
     use super::*;
 
-    #[test]
+    #[tokio::test]
     #[ignore]
-    fn gcloud() {
-        let gcloud = GCloudAuthorizedUser::new().unwrap();
+    async fn gcloud() {
+        let gcloud = GCloudAuthorizedUser::new().await.unwrap();
         println!("{:?}", gcloud.project_id);
-        println!("{:?}", gcloud.token());
+        println!("{:?}", gcloud.get_token(&[""]));
     }
 }


### PR DESCRIPTION
Current implementation for `GCloudAuthorizedUser` is not caching the token got by `gcloud auth print-access-token`. The token is valid for 60m but when using gcp_auth to run some service locally the `gcloud` command is run for each `auth_manager.get_token(...)` call.

This PR adds a `token: RwLock<Token>` in `GCloudAuthorizedUser` just like other accounts that implements `ServiceAccount`, also making the use cases more efficient when calling with `auth_manager.get_token()` by using `GCloudAuthorizedUser`.

---

Demo - effects when updated:
Before (`gcloud auth print-access-token` is run every time when using the manager `get_token(...)`):
```
fuyangl@Fuyangs-MacBook-Pro:~/workspace/bigtable_rs 
(main $) 🦀 👉  curlt localhost:3030/key1
    time_namelookup:  0.006677
       time_connect:  0.007068
    time_appconnect:  0.000000
   time_pretransfer:  0.007101
      time_redirect:  0.000000
 time_starttransfer:  0.800651
                    ----------
         time_total:  0.801008
fuyangl@Fuyangs-MacBook-Pro:~/workspace/bigtable_rs 
(main $) 🦀 👉  curlt localhost:3030/key1
    time_namelookup:  0.006588
       time_connect:  0.007086
    time_appconnect:  0.000000
   time_pretransfer:  0.007133
      time_redirect:  0.000000
 time_starttransfer:  0.688113
                    ----------
         time_total:  0.688453
```

After (token is cached):
```
fuyangl@Fuyangs-MacBook-Pro:~/workspace/bigtable_rs 
(main *) 🦀 👉  curlt localhost:3030/key1
    time_namelookup:  0.006734
       time_connect:  0.007171
    time_appconnect:  0.000000
   time_pretransfer:  0.007209
      time_redirect:  0.000000
 time_starttransfer:  0.047468
                    ----------
         time_total:  0.047594
fuyangl@Fuyangs-MacBook-Pro:~/workspace/bigtable_rs 
(main *) 🦀 👉  curlt localhost:3030/key1
    time_namelookup:  0.006815
       time_connect:  0.007263
    time_appconnect:  0.000000
   time_pretransfer:  0.007308
      time_redirect:  0.000000
 time_starttransfer:  0.049509
                    ----------
         time_total:  0.049676
```