### PR TITLE
Default token expiry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.7.5"
+version = "0.7.6"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -3,12 +3,13 @@ use std::process::Command;
 use std::sync::RwLock;
 
 use async_trait::async_trait;
+use time::Duration;
 use which::which;
 
 use crate::authentication_manager::ServiceAccount;
 use crate::error::Error;
 use crate::error::Error::{GCloudError, GCloudNotFound, GCloudParseError};
-use crate::types::HyperClient;
+use crate::types::{HyperClient, DEFAULT_TOKEN_DURATION};
 use crate::Token;
 
 #[derive(Debug)]
@@ -31,10 +32,10 @@ impl GCloudAuthorizedUser {
     }
 
     fn token(gcloud: &Path) -> Result<Token, Error> {
-        Ok(Token::from_string(run(
-            gcloud,
-            &["auth", "print-access-token", "--quiet"],
-        )?))
+        Ok(Token::from_string(
+            run(gcloud, &["auth", "print-access-token", "--quiet"])?,
+            Duration::seconds(DEFAULT_TOKEN_DURATION),
+        ))
     }
 }
 

--- a/src/gcloud_authorized_user.rs
+++ b/src/gcloud_authorized_user.rs
@@ -3,7 +3,6 @@ use std::process::Command;
 use std::sync::RwLock;
 
 use async_trait::async_trait;
-use time::Duration;
 use which::which;
 
 use crate::authentication_manager::ServiceAccount;
@@ -34,7 +33,7 @@ impl GCloudAuthorizedUser {
     fn token(gcloud: &Path) -> Result<Token, Error> {
         Ok(Token::from_string(
             run(gcloud, &["auth", "print-access-token", "--quiet"])?,
-            Duration::seconds(DEFAULT_TOKEN_DURATION),
+            DEFAULT_TOKEN_DURATION,
         ))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,12 +12,6 @@ use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
 
 use crate::Error;
-
-/// The default number of seconds that it takes for a Google Cloud auth token to expire.
-/// This appears to be the default from practical testing, but we have not found evidence
-/// that this will always be the default duration.
-pub(crate) const DEFAULT_TOKEN_DURATION: Duration = Duration::seconds(3600);
-
 /// Represents an access token. All access tokens are Bearer tokens.
 ///
 /// Tokens should not be cached, the [`AuthenticationManager`] handles the correct caching

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,6 +13,11 @@ use time::{Duration, OffsetDateTime};
 
 use crate::Error;
 
+/// The default number of seconds that it takes for a Google Cloud auth token to expire.
+/// This appears to be the default from practical testing, but we have not found evidence
+/// that this will always be the default duration.
+pub(crate) const DEFAULT_TOKEN_DURATION: i64 = 3600;
+
 /// Represents an access token. All access tokens are Bearer tokens.
 ///
 /// Tokens should not be cached, the [`AuthenticationManager`] handles the correct caching
@@ -32,11 +37,11 @@ pub struct Token {
 }
 
 impl Token {
-    pub(crate) fn from_string(access_token: String) -> Self {
+    pub(crate) fn from_string(access_token: String, expires_in: Duration) -> Self {
         Token {
             inner: Arc::new(InnerToken {
                 access_token,
-                expires_at: OffsetDateTime::now_utc() + Duration::seconds(3600),
+                expires_at: OffsetDateTime::now_utc() + expires_in,
             }),
         }
     }
@@ -191,8 +196,8 @@ mod tests {
     #[test]
     fn test_token_from_string() {
         let s = String::from("abc123");
-        let token = Token::from_string(s);
-        let expires = OffsetDateTime::now_utc() + Duration::seconds(3600);
+        let token = Token::from_string(s, Duration::seconds(DEFAULT_TOKEN_DURATION));
+        let expires = OffsetDateTime::now_utc() + Duration::seconds(DEFAULT_TOKEN_DURATION);
 
         assert_eq!(token.as_str(), "abc123");
         assert!(!token.has_expired());

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ use crate::Error;
 /// The default number of seconds that it takes for a Google Cloud auth token to expire.
 /// This appears to be the default from practical testing, but we have not found evidence
 /// that this will always be the default duration.
-pub(crate) const DEFAULT_TOKEN_DURATION: i64 = 3600;
+pub(crate) const DEFAULT_TOKEN_DURATION: Duration = Duration::seconds(3600);
 
 /// Represents an access token. All access tokens are Bearer tokens.
 ///
@@ -196,8 +196,8 @@ mod tests {
     #[test]
     fn test_token_from_string() {
         let s = String::from("abc123");
-        let token = Token::from_string(s, Duration::seconds(DEFAULT_TOKEN_DURATION));
-        let expires = OffsetDateTime::now_utc() + Duration::seconds(DEFAULT_TOKEN_DURATION);
+        let token = Token::from_string(s, DEFAULT_TOKEN_DURATION);
+        let expires = OffsetDateTime::now_utc() + DEFAULT_TOKEN_DURATION;
 
         assert_eq!(token.as_str(), "abc123");
         assert!(!token.has_expired());

--- a/src/types.rs
+++ b/src/types.rs
@@ -199,6 +199,7 @@ mod tests {
         let token: Token = serde_json::from_str(s).unwrap();
         let expires = OffsetDateTime::now_utc() + Duration::seconds(3600);
 
+        assert_eq!(token.as_str(), "abc123");
         assert!(token.expires_at() < expires + Duration::seconds(1));
         assert!(token.expires_at() > expires - Duration::seconds(1));
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -192,16 +192,4 @@ mod tests {
         assert!(expires_at < expires + Duration::seconds(1));
         assert!(expires_at > expires - Duration::seconds(1));
     }
-
-    #[test]
-    fn test_token_from_string() {
-        let s = String::from("abc123");
-        let token = Token::from_string(s, DEFAULT_TOKEN_DURATION);
-        let expires = OffsetDateTime::now_utc() + DEFAULT_TOKEN_DURATION;
-
-        assert_eq!(token.as_str(), "abc123");
-        assert!(!token.has_expired());
-        assert!(token.expires_at() < expires + Duration::seconds(1));
-        assert!(token.expires_at() > expires - Duration::seconds(1));
-    }
 }


### PR DESCRIPTION
Closes #66 
`GCloudAuthorizedUser::from_string` defaults the token's `expiry_time` to `None`, which causes `Token::has_expired` to always return false. This results in `AuthenticationManager::get_token` never refreshing a token that was retrieved via a `GCloudAuthorizedUser`. I have refactored `InnerToken` to store expiry time as an `OffsetDateTime` instead of an `Option<OffsetDateTime>`, and that will default to 1 hour in the future (3600 seconds).