### PR TITLE
Resolve build failures caused by dependency upgrade

### DIFF
--- a/src/jwt.rs
+++ b/src/jwt.rs
@@ -1,5 +1,7 @@
 //! Copyright (c) 2016 Google Inc (lewinb@google.com).
 
+use base64::engine::general_purpose::URL_SAFE;
+use base64::Engine;
 use serde::Serialize;
 
 use crate::custom_service_account::ApplicationCredentials;
@@ -8,11 +10,6 @@ use crate::types::Signer;
 
 pub(crate) const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
 const GOOGLE_RS256_HEAD: &str = r#"{"alg":"RS256","typ":"JWT"}"#;
-
-/// Encodes s as Base64
-fn append_base64<T: AsRef<[u8]> + ?Sized>(s: &T, out: &mut String) {
-    base64::encode_config_buf(s, base64::URL_SAFE, out)
-}
 
 /// Permissions requested for a JWT.
 /// See https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests.
@@ -55,13 +52,13 @@ impl<'a> Claims<'a> {
 
     pub(crate) fn to_jwt(&self, signer: &Signer) -> Result<String, Error> {
         let mut jwt = String::new();
-        append_base64(GOOGLE_RS256_HEAD, &mut jwt);
+        URL_SAFE.encode_string(GOOGLE_RS256_HEAD, &mut jwt);
         jwt.push('.');
-        append_base64(&serde_json::to_string(self).unwrap(), &mut jwt);
+        URL_SAFE.encode_string(&serde_json::to_string(self).unwrap(), &mut jwt);
 
         let signature = signer.sign(jwt.as_bytes())?;
         jwt.push('.');
-        append_base64(&signature, &mut jwt);
+        URL_SAFE.encode_string(&signature, &mut jwt);
         Ok(jwt)
     }
 }


### PR DESCRIPTION
Dependabot upgraded the `base64` crate from `0.13` to `0.20`. The function `base64::encode_config_buf`, used in `jwt.rs`, has been removed from the crate in that time, which caused the compile errors. The functionality is replaced by the `base64::...::URL_SAFE` engine.