### PR TITLE
Upgrade hyper-rustls to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.7.6"
+version = "0.8.0"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,9 @@ async-trait = "0.1"
 base64 = "0.21"
 dirs-next = "2.0"
 hyper = { version = "0.14.2", features = ["client", "runtime", "http2"] }
-hyper-rustls = { version = "0.23.0", default-features = false, features = ["tokio-runtime", "http1", "http2"] }
+hyper-rustls = { version = "0.24", default-features = false, features = ["tokio-runtime", "http1", "http2"] }
 ring = "0.16.20"
-rustls = "0.20.2"
+rustls = "0.21"
 rustls-pemfile = "1.0.0"
 serde = {version = "1.0", features = ["derive", "rc"]}
 serde_json = "1.0"


### PR DESCRIPTION
Bumps version to 0.8 (since this also upgrades rustls to 0.21, and `rustls::Error` appears in the public API).