### PR TITLE
Reduce Token expiry delta and add get_token retries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.8.0"
+version = "0.8.1"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ hyper-rustls = { version = "0.24", default-features = false, features = ["tokio-
 ring = "0.16.20"
 rustls = "0.21"
 rustls-pemfile = "1.0.0"
-serde = {version = "1.0", features = ["derive", "rc"]}
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "1.0"
 time = { version = "0.3.5", features = ["serde"] }

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -15,7 +15,8 @@ pub(crate) trait ServiceAccount: Send + Sync {
     async fn refresh_token(&self, client: &HyperClient, scopes: &[&str]) -> Result<Token, Error>;
 }
 
-/// Authentication manager is responsible for caching and obtaing credentials for the required scope
+/// Authentication manager is responsible for caching and obtaining credentials for the required
+/// scope
 ///
 /// Construct the authentication manager with [`AuthenticationManager::new()`] or by creating
 /// a [`CustomServiceAccount`], then converting it into an `AuthenticationManager` using the `From`

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,8 +65,14 @@ impl Token {
     ///
     /// This takes an additional 30s margin to ensure the token can still be reasonably used
     /// instead of expiring right after having checked.
+    ///
+    /// Note:
+    /// The official Python implementation uses 20s and states it should be no more than 30s.
+    /// The official Go implementation uses 10s (0s for the metadata server).
+    /// The docs state, the metadata server caches tokens until 5 minutes before expiry.
+    /// We use 20s to be on the safe side.
     pub fn has_expired(&self) -> bool {
-        self.inner.expires_at - Duration::seconds(30) <= OffsetDateTime::now_utc()
+        self.inner.expires_at - Duration::seconds(20) <= OffsetDateTime::now_utc()
     }
 
     /// Get str representation of the token.


### PR DESCRIPTION
This tackles some smaller issues.

First, other, official, SDKs use smaller values than 30s. The [Python SDK uses 20s](https://github.com/googleapis/google-auth-library-python/blob/f19f610ce6afeea74fd634c356abb24192a843b8/google/auth/_helpers.py#L31), and the [Go SDK uses 0s for credentials from the metadata server](https://cs.opensource.google/go/x/oauth2/+/refs/tags/v0.8.0:google/google.go;l=234). 
This PR reduces the delta to 20s, following the Python SDK.

Second, the official SDKs use a retry mechanism for fetching tokens from the various backends. 
This PR adds a retry of at most 5 requests for each fetch token request.

This also bumps the version to 0.8.1. The changes above are internal only and thus are semver compatible for a patch release.