### PR TITLE
Deprioritize GCloudAuthorizedUser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gcp_auth"
-version = "0.8.1"
+version = "0.9.0"
 repository = "https://github.com/hrvolapeter/gcp_auth"
 description = "Google cloud platform (GCP) authentication using default and custom service accounts"
 documentation = "https://docs.rs/gcp_auth/"

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ The library supports the following methods of retrieving tokens in the listed pr
 1. Reading custom service account credentials from the path pointed to by the
    `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Alternatively, custom service
    account credentials can be read from a JSON file or string.
-2. Retrieving a token from the `gcloud` CLI tool, if it is available on the `PATH`.
+2. Look for credentials in `.config/gcloud/application_default_credentials.json`;
+   if found, use these credentials to request refresh tokens. This file can be created
+   by invoking `gcloud auth application-default login`.
 3. Use the default service account by retrieving a token from the metadata server.
-4. Look for credentials in `.config/gcloud/application_default_credentials.json`;
-   if found, use these credentials to request refresh tokens.
+4. Retrieving a token from the `gcloud` CLI tool, if it is available on the `PATH`.
 
 For more detailed information and examples, see the [docs][docs-url].
 

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -3,7 +3,7 @@ use tokio::sync::Mutex;
 
 use crate::custom_service_account::CustomServiceAccount;
 use crate::default_authorized_user::ConfigDefaultCredentials;
-use crate::default_service_account::DefaultServiceAccount;
+use crate::default_service_account::MetadataServiceAccount;
 use crate::error::Error;
 use crate::gcloud_authorized_user::GCloudAuthorizedUser;
 use crate::types::{self, HyperClient, Token};
@@ -56,9 +56,9 @@ impl AuthenticationManager {
             Err(e) => e,
         };
 
-        let default_service_error = match DefaultServiceAccount::new(&client).await {
+        let default_service_error = match MetadataServiceAccount::new(&client).await {
             Ok(service_account) => {
-                tracing::debug!("Using DefaultServiceAccount");
+                tracing::debug!("Using MetadataServiceAccount");
                 return Ok(Self::build(client, service_account));
             }
             Err(e) => e,

--- a/src/authentication_manager.rs
+++ b/src/authentication_manager.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 
 use crate::custom_service_account::CustomServiceAccount;
-use crate::default_authorized_user::DefaultAuthorizedUser;
+use crate::default_authorized_user::ConfigDefaultCredentials;
 use crate::default_service_account::DefaultServiceAccount;
 use crate::error::Error;
 use crate::gcloud_authorized_user::GCloudAuthorizedUser;
@@ -48,9 +48,9 @@ impl AuthenticationManager {
         }
 
         let client = types::client();
-        let default_user_error = match DefaultAuthorizedUser::new(&client).await {
+        let default_user_error = match ConfigDefaultCredentials::new(&client).await {
             Ok(service_account) => {
-                tracing::debug!("Using DefaultAuthorizedUser");
+                tracing::debug!("Using ConfigDefaultCredentials");
                 return Ok(Self::build(client, service_account));
             }
             Err(e) => e,

--- a/src/default_authorized_user.rs
+++ b/src/default_authorized_user.rs
@@ -12,12 +12,12 @@ use crate::types::{HyperClient, Token};
 use crate::util::HyperExt;
 
 #[derive(Debug)]
-pub(crate) struct DefaultAuthorizedUser {
+pub(crate) struct ConfigDefaultCredentials {
     token: RwLock<Token>,
     credentials: UserCredentials,
 }
 
-impl DefaultAuthorizedUser {
+impl ConfigDefaultCredentials {
     const DEFAULT_TOKEN_GCP_URI: &'static str = "https://accounts.google.com/o/oauth2/token";
     const USER_CREDENTIALS_PATH: &'static str =
         ".config/gcloud/application_default_credentials.json";
@@ -77,7 +77,7 @@ impl DefaultAuthorizedUser {
 }
 
 #[async_trait]
-impl ServiceAccount for DefaultAuthorizedUser {
+impl ServiceAccount for ConfigDefaultCredentials {
     async fn project_id(&self, _: &HyperClient) -> Result<String, Error> {
         self.credentials
             .quota_project_id

--- a/src/default_service_account.rs
+++ b/src/default_service_account.rs
@@ -11,11 +11,11 @@ use crate::types::{HyperClient, Token};
 use crate::util::HyperExt;
 
 #[derive(Debug)]
-pub(crate) struct DefaultServiceAccount {
+pub(crate) struct MetadataServiceAccount {
     token: RwLock<Token>,
 }
 
-impl DefaultServiceAccount {
+impl MetadataServiceAccount {
     const DEFAULT_PROJECT_ID_GCP_URI: &'static str =
         "http://metadata.google.internal/computeMetadata/v1/project/project-id";
     const DEFAULT_TOKEN_GCP_URI: &'static str = "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
@@ -61,7 +61,7 @@ impl DefaultServiceAccount {
 }
 
 #[async_trait]
-impl ServiceAccount for DefaultServiceAccount {
+impl ServiceAccount for MetadataServiceAccount {
     async fn project_id(&self, client: &HyperClient) -> Result<String, Error> {
         tracing::debug!("Getting project ID from GCP instance metadata server");
         let req = Self::build_token_request(Self::DEFAULT_PROJECT_ID_GCP_URI);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,11 @@
 //! 1. Reading custom service account credentials from the path pointed to by the
 //!    `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Alternatively, custom service
 //!    account credentials can be read from a JSON file or string.
-//! 2. Retrieving a token from the `gcloud` CLI tool, if it is available on the `PATH`.
+//! 2. Look for credentials in `.config/gcloud/application_default_credentials.json`;
+//!    if found, use these credentials to request refresh tokens. This file can be created
+//!    by invoking `gcloud auth application-default login`.
 //! 3. Use the default service account by retrieving a token from the metadata server.
-//! 4. Look for credentials in `.config/gcloud/application_default_credentials.json`;
-//!    if found, use these credentials to request refresh tokens.
+//! 4. Retrieving a token from the `gcloud` CLI tool, if it is available on the `PATH`.
 //!
 //! For more details, see [`AuthenticationManager::new()`].
 //!


### PR DESCRIPTION
While we're not sure this is a regression since #67 we've recently been seeing elevated error rates in production for some of our code running gcp_auth in a Docker container that has the `gcloud` CLI installed. The error looks like this (this is from a gRPC client call):

```
Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.
```

Code that doesn't have `gcloud` installed in the container seems to be running without errors.

The [documentation](https://cloud.google.com/sdk/gcloud/reference/auth/print-access-token) for the `print-access-token` command also lists some limitations:

> Note that token itself may not be enough to access some services. If you use the token with curl or similar tools, you may see permission errors similar to "API has not been used in project 32555940559 before or it is disabled.". If it happens, you may need to provide a quota project in the "X-Goog-User-Project" header.

> The identity that granted the token must have the serviceusage.services.use permission on the provided project.

We also noted that the order of token acquisition methods tried by the `gcp_auth::AuthenticationManager` doesn't match what official Google SDKs do -- this PR would bring gcp_auth closer in line with official SDKs.

Because this seems like a substantial change to the documented mechanics, I've included a commit that bumps the version number to the next semver-incompatible release (despite there being no actual changes to the public API). When releasing this change we should publish release notes that clearly point out the change.

(I worked with @valkum on this, hope I'm correctly representing his research.)